### PR TITLE
feat: KVS Delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ethersphere/proximity-order-trie
+module github.com/brainiac-five/pot
 
 go 1.24.0
 

--- a/kvs.go
+++ b/kvs.go
@@ -23,6 +23,8 @@ type KeyValueStore interface {
 	Put(ctx context.Context, key, value []byte) error
 	// Save saves key-value pair to the underlying storage and returns the reference.
 	Save(ctx context.Context) ([]byte, error)
+	// Delete takes a key-value pair out of the trie
+	Delete(ctx context.Context, key []byte) error
 }
 
 type SwarmKvs struct {
@@ -88,3 +90,13 @@ func (ps *SwarmKvs) Save(ctx context.Context) ([]byte, error) {
 	}
 	return ref, nil
 }
+
+// Delete takes a key-value pair out of the trie
+func (ps *SwarmKvs) Delete(ctx context.Context, key []byte) error {
+	err := ps.idx.Delete(ctx, key)
+	if err != nil {
+		return fmt.Errorf("failed to delete key-value pair from pot %w", err)
+	}
+	return nil
+}
+

--- a/kvs_test.go
+++ b/kvs_test.go
@@ -85,4 +85,28 @@ func TestPotKvs_Save(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, val2, val)
 	})
+	t.Run("Save KVS and delete one item, test that it is deleted, after-save value exist", func(t *testing.T) {
+		ls := createLs()
+		kvs1, _ := pot.NewSwarmKvs(ls)
+
+		err := kvs1.Put(ctx, key1, val1)
+		assert.NoError(t, err)
+		val, err := kvs1.Get(ctx, key1)
+		assert.NoError(t, err)
+		assert.Equal(t, val1, val)
+		ref, err := kvs1.Save(ctx)
+		assert.NoError(t, err)
+		err = kvs1.Delete(ctx, key1)
+		assert.NoError(t, err)
+		val, err = kvs1.Get(ctx, key1)
+		assert.Error(t, err, "not found")
+
+		// New KVS
+		kvs2, err := pot.NewSwarmKvsReference(ctx, ls, ref)
+		assert.NoError(t, err)
+
+		val, err = kvs2.Get(ctx, key1)
+		assert.NoError(t, err)
+		assert.Equal(t, val1, val)
+	})
 }


### PR DESCRIPTION
The KVS does not have a delete function although the underlying index / element packages have.

This feature allows for the implementation of (proper) delete also in POT JS.