### PR TITLE
Cleanup/entry

### DIFF
--- a/index.go
+++ b/index.go
@@ -74,16 +74,16 @@ func (idx *Index) muxProcess(root elements.Node) {
 
 // Add inserts an entry to the mutable pot
 func (idx *Index) Add(ctx context.Context, e elements.Entry) error {
-	return idx.Update(ctx, e.Key(), func(elements.Entry) elements.Entry { return e })
+	return idx.Update(ctx, e.Key(), &e )
 }
 
 // Delete removes the entry at the given key from the mutable pot
 func (idx *Index) Delete(ctx context.Context, k []byte) error {
-	return idx.Update(ctx, k, func(elements.Entry) elements.Entry { return nil })
+	return idx.Update(ctx, k, nil)
 }
 
 // Update exposes the pot update function more directly
-func (idx *Index) Update(ctx context.Context, k []byte, f func(elements.Entry) elements.Entry) error {
+func (idx *Index) Update(ctx context.Context, k []byte, e *elements.Entry) error {
 	var root elements.Node
 
 	// get the pot root and capture the write lock
@@ -93,7 +93,7 @@ func (idx *Index) Update(ctx context.Context, k []byte, f func(elements.Entry) e
 	case root = <-idx.write:
 	}
 
-	update, err := idx.mode.Update(ctx, root, k, f)
+	update, err := idx.mode.Update(ctx, root, k, e)
 	if err != nil {
 		return err
 	}

--- a/kvs.go
+++ b/kvs.go
@@ -23,6 +23,8 @@ type KeyValueStore interface {
 	Put(ctx context.Context, key, value []byte) error
 	// Save saves key-value pair to the underlying storage and returns the reference.
 	Save(ctx context.Context) ([]byte, error)
+	// Delete takes a key-value pair out of the trie
+	Delete(ctx context.Context, key []byte) error
 }
 
 type SwarmKvs struct {
@@ -88,3 +90,13 @@ func (ps *SwarmKvs) Save(ctx context.Context) ([]byte, error) {
 	}
 	return ref, nil
 }
+
+// Delete takes a key-value pair out of the trie
+func (ps *SwarmKvs) Delete(ctx context.Context, key []byte) error {
+	err := ps.idx.Delete(ctx, key)
+	if err != nil {
+		return fmt.Errorf("failed to delete key-value pair from pot %w", err)
+	}
+	return nil
+}
+

--- a/kvs_test.go
+++ b/kvs_test.go
@@ -85,4 +85,28 @@ func TestPotKvs_Save(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, val2, val)
 	})
+	t.Run("Save KVS and delete one item, test that it is deleted, after-save value exist", func(t *testing.T) {
+		ls := createLs()
+		kvs1, _ := pot.NewSwarmKvs(ls)
+
+		err := kvs1.Put(ctx, key1, val1)
+		assert.NoError(t, err)
+		val, err := kvs1.Get(ctx, key1)
+		assert.NoError(t, err)
+		assert.Equal(t, val1, val)
+		ref, err := kvs1.Save(ctx)
+		assert.NoError(t, err)
+		err = kvs1.Delete(ctx, key1)
+		assert.NoError(t, err)
+		val, err = kvs1.Get(ctx, key1)
+		assert.Error(t, err, "not found")
+
+		// New KVS
+		kvs2, err := pot.NewSwarmKvsReference(ctx, ls, ref)
+		assert.NoError(t, err)
+
+		val, err = kvs2.Get(ctx, key1)
+		assert.NoError(t, err)
+		assert.Equal(t, val1, val)
+	})
 }

--- a/pkg/elements/mode.go
+++ b/pkg/elements/mode.go
@@ -17,7 +17,7 @@ type Mode interface {
 	Up() func(CNode) bool                                                  // dictates which node/entry to promote after deletion
 	Load(context.Context, []byte) (Node, bool, error)                      // loads the pot
 	Save(context.Context) ([]byte, error)                                  // saves the pot
-	Update(context.Context, Node, []byte, func(Entry) Entry) (Node, error) // mode specific update
+	Update(context.Context, Node, []byte, *Entry) (Node, error)            // mode specific update
 }
 
 type SingleOrder struct {
@@ -71,8 +71,8 @@ func (so SingleOrder) Load(context.Context, []byte) (Node, bool, error) {
 }
 
 // Update is mode specific pot update function - NOOP just proxies to pkg wide default
-func (so SingleOrder) Update(ctx context.Context, root Node, k []byte, f func(Entry) Entry) (Node, error) {
-	return Update(ctx, so.New(), NewAt(0, root), k, f, so)
+func (so SingleOrder) Update(ctx context.Context, root Node, k []byte, e *Entry) (Node, error) {
+	return Update(ctx, so.New(), NewAt(0, root), k, e, so)
 }
 
 // Mode for Swarm persisted pots
@@ -124,8 +124,8 @@ func (pm *SwarmPot) Save(ctx context.Context) ([]byte, error) {
 }
 
 // Update builds on the generic Update
-func (pm *SwarmPot) Update(ctx context.Context, root Node, k []byte, f func(Entry) Entry) (Node, error) {
-	update, err := Update(ctx, pm.New(), NewAt(0, root), k, f, pm)
+func (pm *SwarmPot) Update(ctx context.Context, root Node, k []byte, e *Entry) (Node, error) {
+	update, err := Update(ctx, pm.New(), NewAt(0, root), k, e, pm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/elements/ops.go
+++ b/pkg/elements/ops.go
@@ -49,8 +49,8 @@ func Whack(acc Node, n, m CNode) {
 }
 
 // Update
-func Update(ctx context.Context, acc Node, cn CNode, k []byte, eqf func(Entry) Entry, mode Mode) (Node, error) {
-	u, err := update(ctx, acc, cn, k, eqf, mode)
+func Update(ctx context.Context, acc Node, cn CNode, k []byte, e *Entry, mode Mode) (Node, error) {
+	u, err := update(ctx, acc, cn, k, e, mode)
 	if err != nil {
 		return nil, err
 	}
@@ -60,8 +60,7 @@ func Update(ctx context.Context, acc Node, cn CNode, k []byte, eqf func(Entry) E
 	return u, nil
 }
 
-// what `eqf` does(?)
-func update(ctx context.Context, acc Node, cn CNode, k []byte, eqf func(Entry) Entry, mode Mode) (Node, error) {
+func update(ctx context.Context, acc Node, cn CNode, k []byte, entry *Entry, mode Mode) (Node, error) {
 	/**
 	1. **Empty node case**: If target node is empty, simply pin the new entry
 	2. **Exact match case**: Update the entry if needed and use Whack to rebuild
@@ -70,11 +69,10 @@ func update(ctx context.Context, acc Node, cn CNode, k []byte, eqf func(Entry) E
 	5. **Recursive descent**: Using the Mode's policy to determine when to recurse into the trie
 	**/
 	if Empty(cn.Node) {
-		e := eqf(nil)
-		if e == nil {
+		if entry == nil {
 			return nil, nil
 		}
-		acc.Pin(e)
+		acc.Pin(*entry)
 		return acc, nil
 	}
 	cm, match, err := FindNext(ctx, cn, k, mode)
@@ -82,32 +80,30 @@ func update(ctx context.Context, acc Node, cn CNode, k []byte, eqf func(Entry) E
 		return nil, err
 	}
 	if match {
-		orig := cn.Node.Entry()
-		entry := eqf(orig)
 		if entry == nil {
 			node := Pull(acc, cn, mode)
 			return node, nil
 		}
-		if entry.Equal(orig) {
+		orig := cn.Node.Entry()
+		if (*entry).Equal(orig) {
 			return nil, nil
 		}
 		n := mode.New()
-		n.Pin(entry)
+		n.Pin(*entry)
 		Whack(acc, cn, NewAt(mode.Depth(), n))
 		return acc, nil
 	}
 	if Empty(cm.Node) {
-		entry := eqf(nil)
 		if entry == nil {
 			return nil, nil
 		}
 		n := mode.New()
-		n.Pin(entry)
+		n.Pin(*entry)
 		Whirl(acc, cn, NewAt(cm.At, n))
 		return acc, nil
 	}
 	if cm.At == 0 {
-		res, err := update(ctx, acc, cm, k, eqf, mode)
+		res, err := update(ctx, acc, cm, k, entry, mode)
 		if err != nil {
 			return nil, err
 		}
@@ -126,7 +122,7 @@ func update(ctx context.Context, acc Node, cn CNode, k []byte, eqf func(Entry) E
 		return n, nil
 	}
 	if mode.Down(cm) {
-		res, err := update(ctx, mode.New(), cm, k, eqf, mode)
+		res, err := update(ctx, mode.New(), cm, k, entry, mode)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +130,7 @@ func update(ctx context.Context, acc Node, cn CNode, k []byte, eqf func(Entry) E
 		return acc, nil
 	}
 	Whirl(acc, cn, cm)
-	return update(ctx, acc, cm.Next(), k, eqf, mode)
+	return update(ctx, acc, cm.Next(), k, entry, mode)
 }
 
 // Pull handles node removal and restructuring of the trie.


### PR DESCRIPTION
Presumably a residue of a later-changed approach, the function `eqf`, whose sole parameter (`orig`) was never used, can go and be replaced by a pointer to increase readability and be more idiomatic.

note `entry := eqf(orig)` never used `orig`.