### PR TITLE
Fix marshaling

### DIFF
--- a/kvs.go
+++ b/kvs.go
@@ -23,6 +23,8 @@ type KeyValueStore interface {
 	Put(ctx context.Context, key, value []byte) error
 	// Save saves key-value pair to the underlying storage and returns the reference.
 	Save(ctx context.Context) ([]byte, error)
+	// Delete takes a key-value pair out of the trie
+	Delete(ctx context.Context, key []byte) error
 }
 
 type SwarmKvs struct {
@@ -88,3 +90,13 @@ func (ps *SwarmKvs) Save(ctx context.Context) ([]byte, error) {
 	}
 	return ref, nil
 }
+
+// Delete takes a key-value pair out of the trie
+func (ps *SwarmKvs) Delete(ctx context.Context, key []byte) error {
+	err := ps.idx.Delete(ctx, key)
+	if err != nil {
+		return fmt.Errorf("failed to delete key-value pair from pot %w", err)
+	}
+	return nil
+}
+

--- a/kvs_test.go
+++ b/kvs_test.go
@@ -109,4 +109,29 @@ func TestPotKvs_Save(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, val1, val)
 	})
+	t.Run("Save KVS with two items, after-load values exist", func(t *testing.T) {
+		ls := createLs()
+		kvs1, _ := pot.NewSwarmKvs(ls)
+
+		err := kvs1.Put(ctx, key1, val1)
+		assert.NoError(t, err)
+
+		err = kvs1.Put(ctx, key2, val2)
+		assert.NoError(t, err)
+
+		ref, err := kvs1.Save(ctx)
+		assert.NoError(t, err)
+
+		// New KVS
+		kvs2, err := pot.NewSwarmKvsReference(ctx, ls, ref)
+		assert.NoError(t, err)
+
+		val, err := kvs2.Get(ctx, key1)
+		assert.NoError(t, err)
+		assert.Equal(t, val1, val)
+
+		val, err = kvs2.Get(ctx, key2)
+		assert.NoError(t, err)
+		assert.Equal(t, val2, val)
+	})
 }

--- a/kvs_test.go
+++ b/kvs_test.go
@@ -85,4 +85,28 @@ func TestPotKvs_Save(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, val2, val)
 	})
+	t.Run("Save KVS and delete one item, test that it is deleted, after-save value exist", func(t *testing.T) {
+		ls := createLs()
+		kvs1, _ := pot.NewSwarmKvs(ls)
+
+		err := kvs1.Put(ctx, key1, val1)
+		assert.NoError(t, err)
+		val, err := kvs1.Get(ctx, key1)
+		assert.NoError(t, err)
+		assert.Equal(t, val1, val)
+		ref, err := kvs1.Save(ctx)
+		assert.NoError(t, err)
+		err = kvs1.Delete(ctx, key1)
+		assert.NoError(t, err)
+		val, err = kvs1.Get(ctx, key1)
+		assert.Error(t, err, "not found")
+
+		// New KVS
+		kvs2, err := pot.NewSwarmKvsReference(ctx, ls, ref)
+		assert.NoError(t, err)
+
+		val, err = kvs2.Get(ctx, key1)
+		assert.NoError(t, err)
+		assert.Equal(t, val1, val)
+	})
 }

--- a/pkg/elements/persist.go
+++ b/pkg/elements/persist.go
@@ -106,7 +106,7 @@ func (n *SwarmNode) UnmarshalBinary(buf []byte) error {
 	c := 0
 	poMap := make([]int8, 0, 32)
 	for i := 0; i < 256; i++ {
-		if bitMap[i/8]&(1<<(i%8)) != 0 {
+		if bitMap[i/8]&(1<<(7-i%8)) != 0 {
 			poMap = append(poMap, int8(i))
 			c++
 		}


### PR DESCRIPTION
This PR fixes #15 by correcting the fork PO bit decoding in Unmarshaling().

Marshaling and unmarshaling used different bit order within bitMap.

This PR adds `7-` to 

https://github.com/ethersphere/proximity-order-trie/blob/3096481421a01cc3f9624250e6781c7e041cd943/pkg/elements/persist.go#L108-L112

to become

https://github.com/brainiac-five/pot/blob/a39473f129580ccb1db627856d6c4f9de004c0c4/pkg/elements/persist.go#L108-L112

Alternatively the marshaling could be changed to take the `7-` out in 

https://github.com/ethersphere/proximity-order-trie/blob/3096481421a01cc3f9624250e6781c7e041cd943/pkg/elements/persist.go#L68-L71

Both ways work and pass all tests in this project and potjs.

The assumption of this PR is that going from left to right within a byte (from highest bit down) like PO calculation in 

https://github.com/ethersphere/proximity-order-trie/blob/3096481421a01cc3f9624250e6781c7e041cd943/pkg/elements/pot.go#L223-L228

is the intended way.

Without the fix of this PR the new test

https://github.com/brainiac-five/pot/blob/a39473f129580ccb1db627856d6c4f9de004c0c4/kvs_test.go#L112-L136

fails with:

```
--- FAIL: TestPotKvs_Save (0.00s)
    --- FAIL: TestPotKvs_Save/Save_KVS_with_two_items,_after-load_values_exist (0.00s)
        kvs_test.go:140: 
            	Error Trace:	/Users/b5/gopot/kvs_test.go:140
            	Error:      	Received unexpected error:
            	            	not found
            	Test:       	TestPotKvs_Save/Save_KVS_with_two_items,_after-load_values_exist
        kvs_test.go:141: 
            	Error Trace:	/Users/b5/gopot/kvs_test.go:141
            	Error:      	Not equal: 
            	            	expected: []byte{0x90, 0xf3, 0xe9, 0xad, 0x9b, 0x11, 0xa0, 0xe5, 0xaf, 0x7c, 0xf0, 0x5b, 0xf9, 0xd, 0xb0, 0x49, 0x43, 0xba, 0x62, 0x82, 0x3, 0xb3, 0x11, 0x6e, 0x33, 0xf7, 0xe, 0x28, 0xa4, 0x11, 0xb8, 0x5e, 0x8b, 0x94, 0x22, 0x23, 0xc8, 0x3a, 0x98, 0x4, 0x78, 0xd3, 0xb3, 0xda, 0x15, 0x51, 0x58, 0x3a, 0x8b, 0xc0, 0xea, 0x62, 0xf8, 0xe2, 0xe1, 0x2f, 0xf5, 0x3b, 0x56, 0x2a, 0x19, 0xf8, 0x33, 0xc, 0x47, 0x96, 0xc2, 0xf5, 0x8c, 0xaa, 0x10, 0x1b, 0x83, 0xc, 0x3, 0xd0, 0xf9, 0xa3, 0xc2, 0x65, 0xad, 0xb4, 0xba, 0x3, 0xc, 0x9e, 0xf6, 0xb8, 0x8c, 0xa3, 0xc8, 0xe8, 0x49, 0xb3, 0xb1, 0x1b}
            	            	actual  : []byte(nil)
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,9 +1,2 @@
            	            	-([]uint8) (len=96) {
            	            	- 00000000  90 f3 e9 ad 9b 11 a0 e5  af 7c f0 5b f9 0d b0 49  |.........|.[...I|
            	            	- 00000010  43 ba 62 82 03 b3 11 6e  33 f7 0e 28 a4 11 b8 5e  |C.b....n3..(...^|
            	            	- 00000020  8b 94 22 23 c8 3a 98 04  78 d3 b3 da 15 51 58 3a  |.."#.:..x....QX:|
            	            	- 00000030  8b c0 ea 62 f8 e2 e1 2f  f5 3b 56 2a 19 f8 33 0c  |...b.../.;V*..3.|
            	            	- 00000040  47 96 c2 f5 8c aa 10 1b  83 0c 03 d0 f9 a3 c2 65  |G..............e|
            	            	- 00000050  ad b4 ba 03 0c 9e f6 b8  8c a3 c8 e8 49 b3 b1 1b  |............I...|
            	            	-}
            	            	+([]uint8) <nil>
            	            	 
            	Test:       	TestPotKvs_Save/Save_KVS_with_two_items,_after-load_values_exist
FAIL
exit status 1
FAIL	github.com/ethersphere/proximity-order-trie	1.208s
```

This test should obviously work. What it adds is to have two elements being saved and retrieved after loading the kvs, instead of only one like other tests do.

This PR also has the correct go.mod package name `ethersphere/proximity-order-trie`.