### PR TITLE
fix: missing kvs close (only that)

### DIFF
--- a/kvs.go
+++ b/kvs.go
@@ -99,7 +99,6 @@ func (ps *SwarmKvs) Delete(ctx context.Context, key []byte) error {
 	}
 	return nil
 }
- 
 // Close shuts down the index and stops the background process loop.
 func (ps *SwarmKvs) Close() error {
 	return ps.idx.Close()

--- a/kvs.go
+++ b/kvs.go
@@ -99,4 +99,9 @@ func (ps *SwarmKvs) Delete(ctx context.Context, key []byte) error {
 	}
 	return nil
 }
+ 
+// Close stops the mutex
+func (ps *SwarmKvs) Close() error {
+	return ps.idx.Close()
+}
 

--- a/kvs.go
+++ b/kvs.go
@@ -100,7 +100,7 @@ func (ps *SwarmKvs) Delete(ctx context.Context, key []byte) error {
 	return nil
 }
  
-// Close stops the mutex
+// Close shuts down the index and stops the background process loop.
 func (ps *SwarmKvs) Close() error {
 	return ps.idx.Close()
 }

--- a/kvs_test.go
+++ b/kvs_test.go
@@ -146,5 +146,5 @@ func TestPotKvs_Save(t *testing.T) {
 
 		err = kvs1.Close()
 		assert.NoError(t, err)
-       })
+	})
 }

--- a/kvs_test.go
+++ b/kvs_test.go
@@ -134,4 +134,17 @@ func TestPotKvs_Save(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, val2, val)
 	})
+	t.Run("Create KVS, write to it, close it", func(t *testing.T) {
+		ls := createLs()
+		kvs1, _ := pot.NewSwarmKvs(ls)
+
+		err := kvs1.Put(ctx, key1, val1)
+		assert.NoError(t, err)
+
+		_, err = kvs1.Save(ctx)
+		assert.NoError(t, err)
+
+		err = kvs1.Close()
+		assert.NoError(t, err)
+       })
 }


### PR DESCRIPTION
Adding the missing Close() function to KVS.

Fixes https://github.com/ethersphere/proximity-order-trie/issues/18.